### PR TITLE
Listen for printer changes and refresh the printers list when it happ…

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,1 @@
+theme: jekyll-theme-cayman

--- a/gcp-windows-connector/gcp-windows-connector.go
+++ b/gcp-windows-connector/gcp-windows-connector.go
@@ -171,6 +171,16 @@ func (service *service) Execute(args []string, r <-chan svc.ChangeRequest, s cha
 	}
 	defer pm.Quit()
 
+	statusHandle := svc.StatusHandle()
+	if statusHandle != 0 {
+		err = ws.StartPrinterNotifications(statusHandle)
+		if err != nil {
+			log.Error(err)
+		} else {
+			log.Info("Successfully registered for device notifications.")
+		}
+	}
+
 	if config.CloudPrintingEnable {
 		if config.LocalPrintingEnable {
 			log.Infof("Ready to rock as proxy '%s' and in local mode", config.ProxyName)
@@ -197,6 +207,15 @@ func (service *service) Execute(args []string, r <-chan svc.ChangeRequest, s cha
 			})
 
 			return false, 0
+
+		case svc.DeviceEvent:
+			log.Infof("Printers change notification received %d.", request.EventType)
+			// Delay the action to let the OS finish the process or we might
+			// not see the new printer. Even if we miss it eventually the timed updates
+			// will pick it up.
+			time.AfterFunc(time.Second*5, func() {
+				pm.SyncPrinters(false)
+			})
 
 		default:
 			log.Errorf("Received unsupported service command from service control manager: %d", request.Cmd)

--- a/lib/printer.go
+++ b/lib/printer.go
@@ -239,7 +239,7 @@ func FilterBlacklistPrinters(printers []Printer, list map[string]interface{}) []
 
 func FilterWhitelistPrinters(printers []Printer, list map[string]interface{}) []Printer {
 	if len(list) == 0 {
-		return printers; // Empty whitelist means don't use whitelist
+		return printers // Empty whitelist means don't use whitelist
 	}
 
 	return filterPrinters(printers, list, true)

--- a/lib/printer_test.go
+++ b/lib/printer_test.go
@@ -9,22 +9,22 @@ https://developers.google.com/open-source/licenses/bsd
 package lib
 
 import (
-	"testing"
 	"reflect"
+	"testing"
 )
 
 func TestFilterBlacklistPrinters(t *testing.T) {
-	printers := []Printer {
+	printers := []Printer{
 		{Name: "Stay1"},
 		{Name: "Go1"},
 		{Name: "Go2"},
 		{Name: "Stay2"},
 	}
-	blacklist := map[string]interface{} {
+	blacklist := map[string]interface{}{
 		"Go1": "",
 		"Go2": "",
 	}
-	correctFilteredPrinters := []Printer {
+	correctFilteredPrinters := []Printer{
 		{Name: "Stay1"},
 		{Name: "Stay2"},
 	}
@@ -37,17 +37,17 @@ func TestFilterBlacklistPrinters(t *testing.T) {
 }
 
 func TestFilterWhitelistPrinters(t *testing.T) {
-	printers := []Printer {
+	printers := []Printer{
 		{Name: "Stay1"},
 		{Name: "Go1"},
 		{Name: "Go2"},
 		{Name: "Stay2"},
 	}
-	whitelist := map[string]interface{} {
+	whitelist := map[string]interface{}{
 		"Stay1": "",
 		"Stay2": "",
 	}
-	correctFilteredPrinters := []Printer {
+	correctFilteredPrinters := []Printer{
 		{Name: "Stay1"},
 		{Name: "Stay2"},
 	}

--- a/manager/printermanager.go
+++ b/manager/printermanager.go
@@ -105,7 +105,7 @@ func NewPrinterManager(native NativePrintSystem, gcp *gcp.GoogleCloudPrint, priv
 	// Sync once before returning, to make sure things are working.
 	// Ignore privet updates this first time because Privet always starts
 	// with zero printers.
-	if err = pm.syncPrinters(true); err != nil {
+	if err = pm.SyncPrinters(true); err != nil {
 		return nil, err
 	}
 
@@ -146,7 +146,7 @@ func (pm *PrinterManager) syncPrintersPeriodically(interval time.Duration) {
 		for {
 			select {
 			case <-t.C:
-				if err := pm.syncPrinters(false); err != nil {
+				if err := pm.SyncPrinters(false); err != nil {
 					log.Error(err)
 				}
 				t.Reset(interval)
@@ -158,7 +158,7 @@ func (pm *PrinterManager) syncPrintersPeriodically(interval time.Duration) {
 	}()
 }
 
-func (pm *PrinterManager) syncPrinters(ignorePrivet bool) error {
+func (pm *PrinterManager) SyncPrinters(ignorePrivet bool) error {
 	log.Info("Synchronizing printers, stand by")
 
 	// Get current snapshot of native printers.
@@ -442,7 +442,7 @@ func (pm *PrinterManager) printJob(nativePrinterName, filename, title, user, job
 	}
 }
 
-func (pm *PrinterManager)releaseJob(printerName string, nativeJobID uint32, jobID string) {
+func (pm *PrinterManager) releaseJob(printerName string, nativeJobID uint32, jobID string) {
 	if err := pm.native.ReleaseJob(printerName, nativeJobID); err != nil {
 		log.ErrorJob(jobID, err)
 	}

--- a/winspool/winspool.go
+++ b/winspool/winspool.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/google/cloud-print-connector/cdd"
 	"github.com/google/cloud-print-connector/lib"
+	"golang.org/x/sys/windows"
 )
 
 // winspoolPDS represents capabilities that WinSpool always provides.
@@ -916,6 +917,11 @@ func (ws *WinSpool) ReleaseJob(printerName string, jobID uint32) error {
 	}
 
 	return nil
+}
+
+func (ws *WinSpool) StartPrinterNotifications(handle windows.Handle) error {
+	err := RegisterDeviceNotification(handle)
+	return err
 }
 
 // The following functions are not relevant to Windows printing, but are required by the NativePrintSystem interface.


### PR DESCRIPTION
…ens (#361)

* Listen for printer changes and refresh the printers list when such happen.

This reduces the delay after new printer is added until it shows up
as a printer avaiable for printing in Goolge Cloud Print on Windows.

Timer based refreshes still need to happen due to other sources of
printers eg Privet etc.

* Adjust the code to the commited version of golang.org/x/sys/windows/svc.